### PR TITLE
Added octave compatibility to run demo #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The features extracted in a bag-of-words manner ('color', 'hog2x2', 'hog3x3', 's
 
 In my experients, I have found 'hog2x2' or 'hog3x3' to be most effective as global image features, and tend to perform even better when combined with 'color' features which contain complementary information.
 
+The toolbox works on Matlab and Octave. Octave may still have some compatibility issues though and doesn't
+support paralell processing.
+
 Installation
 ------------
 Before you can use the code, you need to download this repository and compile the mex code:
@@ -19,6 +22,7 @@ Before you can use the code, you need to download this repository and compile th
     >> compile
     
 To the best of my knowledge, there should be no issues compiling on Linux, Mac or Windows.
+Octave currently isn't able to compile, but most features should be working.
 
 Basic usage
 -----------

--- a/util/batch_feature.m
+++ b/util/batch_feature.m
@@ -56,4 +56,11 @@ else
     feat = {};
 end
 
-save(feature_file, 'feat', 'batch_files', '-v7.3');
+
+if exist('OCTAVE_VERSION','builtin')
+    save(feature_file, 'feat', 'batch_files', '-v7');
+else
+    % I guess matlab could also use v7 instead uses less storage
+    % and is faster see: http://stackoverflow.com/q/4950630/376445
+    save(feature_file, 'feat', 'batch_files', '-v7.3');
+end

--- a/util/conf.m
+++ b/util/conf.m
@@ -48,5 +48,16 @@ c.verbosity = 0;
 c.precision = 'single';
 
 % Reset the random seed
-stream = RandStream('mt19937ar','Seed', sum(1000*clock));
-RandStream.setGlobalStream(stream);
+seed = sum(1000*clock);
+
+if exist('OCTAVE_VERSION','builtin')
+    rand('state',seed);  % Octave
+    randn('state',seed); % Octave
+else
+    try
+        RandStream.setDefaultStream(RandStream('mt19937ar','seed',seed)); % matlab 7.9+
+    catch
+        rand('state',seed);  % Matlab 5+
+        randn('state',seed); % Matlab 5+
+    end
+end

--- a/util/datasets_feature.m
+++ b/util/datasets_feature.m
@@ -12,7 +12,9 @@ if(~exist('c', 'var'))
   c = conf();
 end
 
-openPool(c.cores);
+if (~exist('OCTAVE_VERSION','builtin'))
+    openPool(c.cores);
+end
 
 if(c.common_dictionary)
     c.feature_config.(feature).dictionary = build_dictionary(train_lists, feature, c);


### PR DESCRIPTION
- Fixed save function to save as v7 format if octave
  is used.
- When Octave is used don't use RandStream to set the
  seed.
- When Octave is used don't create a matlabpool, this
  means that octave users currently can't use the
  multicore functionality. But Matlab users are
  still able to.
- Updated readme about octave compatibility

NOTE: There may still be other compatibility issues
I only made it possible to run the Demo on octave.

This patch does not influence any of the existing
matlab behaviour and checks whether the user uses
Octave. It should be a relatively "safe" patch.

I'm still an Octave/Matlab beginner so careful review
would be appreciated.
